### PR TITLE
Fix curl appconnect time parsing

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -36,7 +36,13 @@ class CurlHelper
         \CURLINFO_CONTENT_LENGTH_DOWNLOAD => 'download_content_length',
         \CURLINFO_CONTENT_LENGTH_UPLOAD => 'upload_content_length',
         \CURLINFO_CONTENT_TYPE => 'content_type',
+        \CURLINFO_APPCONNECT_TIME => 'appconnect_time',
     ];
+
+    /**
+     * How many items we expect in the curlinfo array - should correspond to the above list count
+     */
+    const CURLINFO_ITEMS_COUNT = 22;
 
     /**
      * Outputs a response depending on the set cURL option.
@@ -107,6 +113,7 @@ class CurlHelper
                 $info = mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
             case \CURLPROXY_HTTPS:
+            case \CURLINFO_APPCONNECT_TIME:
                 $info = '';
                 break;
             default:

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -68,9 +68,20 @@ class HttpUtil
      */
     public static function parseResponse(string $response): array
     {
-        $response = str_replace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
+        $parts = explode("\r\n\r\n", $response);
 
-        [$rawHeader, $rawBody] = explode("\r\n\r\n", $response, 2);
+        $headerIndex = 0;
+        foreach ($parts as $index => $part) {
+            if (str_starts_with($part, 'HTTP/')) {
+                $headerIndex = $index;
+            } else {
+                break;
+            }
+        }
+
+        $rawHeader = $parts[$headerIndex];
+        $bodyParts = \array_slice($parts, $headerIndex + 1);
+        $rawBody = implode('\r\n\r\n', $bodyParts);
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -12,6 +12,7 @@ use VCR\Configuration;
 use VCR\LibraryHooks\CurlHook;
 use VCR\Request;
 use VCR\Response;
+use VCR\Util\CurlHelper;
 use VCR\Util\StreamProcessor;
 
 final class CurlHookTest extends TestCase
@@ -226,8 +227,10 @@ final class CurlHookTest extends TestCase
         $info = curl_getinfo($curlHandle);
         curl_close($curlHandle);
 
+        $expectedCount = CurlHelper::CURLINFO_ITEMS_COUNT;
+
         $this->assertIsArray($info, 'curl_getinfo() should return an array.');
-        $this->assertCount(21, $info, 'curl_getinfo() should return 21 values.');
+        $this->assertCount($expectedCount, $info, 'curl_getinfo() should return '. $expectedCount .' values.');
         $this->curlHook->disable();
     }
 

--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -96,6 +96,23 @@ final class HttpUtilTest extends TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
 
+    public function testParseMultipleResponseCodes(): void
+    {
+        $raw = "HTTP/1.1 200 OK\r\n\r\nHTTP/1.1 200 OK\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $expectedHeaders = [
+            'Content-Type: text/html',
+            'Date: Fri, 19 Jun 2015 16:05:18 GMT',
+            'Vary: Accept-Encoding',
+            'Content-Length: 0',
+        ];
+
+        $this->assertEquals('HTTP/1.1 201 Created', $status);
+        $this->assertEquals('', $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
     public function testParseHeadersBasic(): void
     {
         $inputArray = [


### PR DESCRIPTION
Porting fixes from my colleague @sf-cg  here - https://github.com/sf-cg/php-vcr

I also updated one of the new tests to be compatible with this change and be a bit more robust with the count of items we're getting from curlinfo