### PR TITLE
Add return type to AbstractCodeTransform::filter

### DIFF
--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -37,7 +37,7 @@ abstract class AbstractCodeTransform extends \php_user_filter
      *
      * @see http://www.php.net/manual/en/php-user-filter.filter.php
      */
-    public function filter($in, $out, &$consumed, $closing)
+    public function filter($in, $out, &$consumed, $closing): int
     {
         while ($bucket = stream_bucket_make_writeable($in)) {
             $bucket->data = $this->transformCode($bucket->data);


### PR DESCRIPTION
Add return type to AbstractCodeTransform::filter

From: https://github.com/php-vcr/php-vcr/pull/366