### PR TITLE
Pass url into curlinfo hook for effective url

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -281,6 +281,7 @@ class CurlHook implements LibraryHook
         if (isset(self::$responses[(int) $curlHandle])) {
             return CurlHelper::getCurlOptionFromResponse(
                 self::$responses[(int) $curlHandle],
+                self::$requests[(int) $curlHandle]->getUrl(),
                 $option
             );
         } elseif (isset(self::$lastErrors[(int) $curlHandle])) {

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -82,13 +82,15 @@ class CurlHelper
     }
 
     /**
-     * @param int $option cURL option to get
+     * @param Response    $response response to get cURL option from
+     * @param string|null $url      the URL this response is for
+     * @param int         $option   cURL option to get
      *
      * @throws \BadMethodCallException
      *
      * @return mixed value of the cURL option
      */
-    public static function getCurlOptionFromResponse(Response $response, int $option = 0)
+    public static function getCurlOptionFromResponse(Response $response, ?string $url, int $option = 0)
     {
         switch ($option) {
             case 0: // 0 == array of all curl options
@@ -108,6 +110,9 @@ class CurlHelper
                 break;
             case \CURLPROXY_HTTPS:
                 $info = '';
+                break;
+          case \CURLINFO_EFFECTIVE_URL:
+                $info = $url;
                 break;
             default:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option]);

--- a/tests/Unit/Util/CurlHelperTest.php
+++ b/tests/Unit/Util/CurlHelperTest.php
@@ -407,7 +407,7 @@ final class CurlHelperTest extends TestCase
     {
         $this->assertEquals(
             $expectedCurlOptionValue,
-            CurlHelper::getCurlOptionFromResponse($response, $curlOption)
+            CurlHelper::getCurlOptionFromResponse($response, '', $curlOption)
         );
     }
 


### PR DESCRIPTION
### Context

When checking for errors in a `curl_multi` I pull the effective url to log with the error.
```php
$url = curl_getinfo($curl_handles[$x], CURLINFO_EFFECTIVE_URL);
```
Which currently fails with php-vcr
```
BadMethodCallException: Not implemented: CURLINFO_EFFECTIVE_URL (1048577)
```
IMHO it really should just return the request url parameter from the source YAML.

### What has been done

- Added a nullable string parameter to the `getCurlOptionFromResponse` to pass in the URL (or null)
- Get the url from the `self::$requests` array of VCR\Request objects

### How to test

- Before if you did a command like above you get the above error. 
- Now you should get the url provided in the `request -> url` parameter

### Todo

- [ ]
- [ ]

### Notes

