### PR TITLE
Added return types for 8-1 compatibility Iterator implementations

### DIFF
--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -68,7 +68,7 @@ abstract class AbstractStorage implements Storage
      *
      * @return array<string,mixed>|null parsed current record
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->current;
     }

--- a/src/VCR/Storage/Blackhole.php
+++ b/src/VCR/Storage/Blackhole.php
@@ -35,10 +35,9 @@ class Blackhole implements Storage
         throw new \BadMethodCallException('Not implemented');
     }
 
-    /** @return array<mixed>|null */
-    public function next(): ?array
+    /** @return void */
+    public function next(): void
     {
-        return null;
     }
 
     public function rewind(): void

--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -88,7 +88,7 @@ class Yaml extends AbstractStorage
         $this->position = 0;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         if (null === $this->current) {
             $this->next();

--- a/tests/Unit/Storage/AbstractStorageTest.php
+++ b/tests/Unit/Storage/AbstractStorageTest.php
@@ -51,7 +51,7 @@ class TestStorage extends AbstractStorage
     {
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return (bool) $this->position;
     }


### PR DESCRIPTION
### Context
Need to bring package up to PHP8.1 compatibility

### What has been done

Modified various iterator implementations to match 8.1 iterator interface https://www.php.net/manual/en/class.iterator.php

### How to test
Appears to work for 8.0 and 8.1. If you wish to test in 8.1 update the dockerfile to:
`FROM php:8.1-cli-alpine`
And run tests as usual.

Note: No extra tests have been added


