### PR TITLE
StreamProcessor::url_stat() throws error when file doesnt exist with phpunit 10

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -300,7 +300,11 @@ class StreamProcessor
                 // Use native error handler
                 return false;
             });
-            $result = @stat($path);
+            try {
+                $result = @stat($path);
+            } catch (Throwable) {
+                $result = false;
+            }
             restore_error_handler();
         } else {
             $result = stat($path);

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace VCR\Util;
 
+use Throwable;
 use VCR\CodeTransform\AbstractCodeTransform;
 use VCR\Configuration;
 


### PR DESCRIPTION
### Context

stat() throws an error for a non-existent file and still throws a fatal error despite the custom error handling
<img width="1909" height="466" alt="image" src="https://github.com/user-attachments/assets/bef5da9c-f049-43f8-a899-ad01df1c6074" />


### What has been done

Trap the with a try/catch and return false

### How to test

Run the `(new StreamProcessor())->url_stat('/tmp/does-not-exist', 1);`

### Todo

- [ ]
- [ ]

### Notes

-
-


