### PR TITLE
fix: return CURLM_OK from intercepted curl_multi_add_handle

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -184,13 +184,18 @@ class CurlHook implements LibraryHook
      *
      * @see http://www.php.net/manual/en/function.curl-multi-add-handle.php
      */
-    public static function curlMultiAddHandle(\CurlMultiHandle $multiHandle, \CurlHandle $curlHandle): void
+    public static function curlMultiAddHandle(\CurlMultiHandle $multiHandle, \CurlHandle $curlHandle): int
     {
         if (!isset(self::$multiHandles[(int) $multiHandle])) {
             self::$multiHandles[(int) $multiHandle] = [];
         }
 
         self::$multiHandles[(int) $multiHandle][(int) $curlHandle] = $curlHandle;
+
+        // Mirror the real curl_multi_add_handle() return contract. Callers such as
+        // Guzzle >= 7.13 strictly check `\CURLM_OK !== $result` and throw otherwise;
+        // returning void (null) here made that check fail with "No error (0)".
+        return \CURLM_OK;
     }
 
     /**

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -444,9 +444,7 @@ final class CurlHookTest extends TestCase
     public function testCurlMultiAddHandleReturnsCurlmOk(): void
     {
         $this->curlHook->enable(
-            function (Request $request): Response {
-                return new Response('200');
-            }
+          fn (Request $request): Response => new Response('200')
         );
 
         $curlHandle = curl_init('http://example.com');

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -444,7 +444,7 @@ final class CurlHookTest extends TestCase
     public function testCurlMultiAddHandleReturnsCurlmOk(): void
     {
         $this->curlHook->enable(
-          fn (Request $request): Response => new Response('200')
+            fn (Request $request): Response => new Response('200')
         );
 
         $curlHandle = curl_init('http://example.com');

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -441,6 +441,33 @@ final class CurlHookTest extends TestCase
         );
     }
 
+    public function testCurlMultiAddHandleReturnsCurlmOk(): void
+    {
+        $this->curlHook->enable(
+            function (Request $request): Response {
+                return new Response('200');
+            }
+        );
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+
+        $curlMultiHandle = curl_multi_init();
+        Assertion::notSame($curlMultiHandle, false);
+
+        // Real curl_multi_add_handle() returns CURLM_OK (0) on success. Guzzle >= 7.13
+        // strictly checks `\CURLM_OK !== $result` and throws when it is not returned,
+        // so the intercepted call must mirror that contract rather than return void.
+        $result = curl_multi_add_handle($curlMultiHandle, $curlHandle);
+
+        curl_multi_remove_handle($curlMultiHandle, $curlHandle);
+        curl_multi_close($curlMultiHandle);
+
+        $this->curlHook->disable();
+
+        $this->assertSame(\CURLM_OK, $result, 'Intercepted curl_multi_add_handle should return CURLM_OK.');
+    }
+
     /**
      * @requires PHP 5.5.0
      */


### PR DESCRIPTION
The real curl_multi_add_handle() returns CURLM_OK (0) on success. The CurlHook interception was declared : void and returned null.

Guzzle >= 7.13 (CurlMultiHandler::addCurlHandle) strictly checks `\CURLM_OK !== $result` and throws a RequestException otherwise. Under php-vcr this call is rewritten to CurlHook::curl_multi_add_handle, so the null return produced:

  Unable to add the cURL handle to the cURL multi handler: No error (0).

Returning \CURLM_OK mirrors the real function's contract. Older Guzzle (<= 7.9.x) discards the return value, so this change should be safely backwards-compatible.
